### PR TITLE
Fix namespace for ArrayRules class

### DIFF
--- a/src/BelongsToManyField.php
+++ b/src/BelongsToManyField.php
@@ -2,7 +2,7 @@
 
 namespace OsTheNeo\NovaFields;
 
-use OsTheNeo\Fields\Rules\ArrayRules;
+use OsTheNeo\NovaFields\Rules\ArrayRules;
 use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Fields\ResourceRelationshipGuesser;
 use Laravel\Nova\Http\Requests\NovaRequest;

--- a/src/Rules/ArrayRules.php
+++ b/src/Rules/ArrayRules.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OsTheNeo\Fields\Rules;
+namespace OsTheNeo\NovaFields\Rules;
 
 use Illuminate\Contracts\Validation\Rule;
 


### PR DESCRIPTION
As mentioned in issue #4 it is not possible to use rules with the BelongsToManyField. This is due to an incorrect namespace for the ArrayRules class. This pr fixes the namespace.